### PR TITLE
Replace machbarmacher/gdpr-dump with druidfi/gdpr-mysqldump

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ be GDPR compliant YO!
 
 This module can be configured by editing the `gdpr_dumper.settings.yml` [file](https://github.com/robiningelbrecht/gdpr-dumper/blob/master/config/install/gdpr_dumper.settings.yml).
 
-[machbarmacher/gdpr-dump](https://github.com/machbarmacher/gdpr-dump) contains more info about 
+[druidfi/gdpr-mysqldump](https://github.com/druidfi/gdpr-mysqldump) contains more info about 
 the **gdpr-expressions** and **gdpr-replacement** options. 
 
 The provided yml file expects the same structure as explained in the readme above.

--- a/composer.json
+++ b/composer.json
@@ -10,23 +10,13 @@
       "name": "Robin Ingelbrecht",
       "homepage": "https://github.com/robiningelbrecht",
       "role": "Maintainer"
+    },
+    {
+      "name": "Marko Korhonen",
+      "homepage": "https://github.com/back-2-95"
     }
   ],
   "require": {
-    "machbarmacher/gdpr-dump": "^1.0.0"
-  },
-  "repositories": [
-    {
-      "type": "package",
-      "package": {
-        "name": "machbarmacher/gdpr-dump",
-        "version": "1.0.0",
-        "source": {
-          "url": "https://github.com/machbarmacher/gdpr-dump.git",
-          "type": "git",
-          "reference": "master"
-        }
-      }
-    }
-  ]
+    "druidfi/gdpr-mysqldump": "dev-main"
+  }
 }

--- a/src/Sql/GdprSqlTrait.php
+++ b/src/Sql/GdprSqlTrait.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\gdpr_dumper\Sql;
 
-use Drupal\Console\Core\Utils\DrupalFinder;
+use DrupalFinder\DrupalFinder;
 
 /**
  * Trait GdprSqlTrait


### PR DESCRIPTION
- Replace `machbarmacher/gdpr-dump` with `druidfi/gdpr-mysqldump`
- Helps install with PHP 7
- Fixed `DrupalFinder` as drush command gave an error
- druidfi/gdpr-mysqldump includes https://github.com/machbarmacher/gdpr-dump/pull/50 and https://github.com/machbarmacher/gdpr-dump/pull/53 